### PR TITLE
Ignore negative deltas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target/
 .idea/
 benchmark.iml
+src/main/main\.iml
+
+src/test/test\.iml

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ benchmark.iml
 src/main/main\.iml
 
 src/test/test\.iml
+
+work/

--- a/src/main/java/org/jenkinsci/plugins/benchmark/parsers/JsonToPlugin/MapJsonThreshold.java
+++ b/src/main/java/org/jenkinsci/plugins/benchmark/parsers/JsonToPlugin/MapJsonThreshold.java
@@ -43,7 +43,8 @@ public class MapJsonThreshold {
         tt_minimum,
         tt_maximum,
         tt_delta,
-        tt_percentage
+        tt_percentage,
+        tt_ignoreNegativeDeltas
     }
 
     // Variables
@@ -52,6 +53,7 @@ public class MapJsonThreshold {
     private Double maximum;
     private Double delta;
     private Double percentage;
+    private Boolean ignoreNegativeDeltas;
 
     private Threshold threshold;
 
@@ -145,6 +147,25 @@ public class MapJsonThreshold {
                             }
                         }
                         break;
+
+                    case tt_ignoreNegativeDeltas:
+                        if (ignoreNegativeDeltas == null){
+                            for (Map.Entry<String, JsonElement> enContent : oContent.entrySet()) {
+                                if (schemaKey.equals(enContent.getKey())) {
+                                    JsonElement value = enContent.getValue();
+                                    if (value.isJsonPrimitive()) {
+                                        JsonPrimitive primitive = value.getAsJsonPrimitive();
+                                        if (primitive.isNumber()) {
+                                            ignoreNegativeDeltas = primitive.getAsBoolean();
+                                            break;
+                                        } else {
+                                            throw new ValidationException(Messages.MapJsonThreshold_WrongFormatForIgnoreNegativeDeltas());
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        break;
                 }
             }
         }
@@ -227,6 +248,8 @@ public class MapJsonThreshold {
             return ThresholdTags.tt_delta;
         else if (type.equals("percentage"))
             return ThresholdTags.tt_percentage;
+        else if (type.equals("ignoreNegativeDeltas"))
+            return ThresholdTags.tt_ignoreNegativeDeltas;
         else
             return ThresholdTags.tt_unknown;
     }

--- a/src/main/java/org/jenkinsci/plugins/benchmark/parsers/JsonToPlugin/MapJsonThreshold.java
+++ b/src/main/java/org/jenkinsci/plugins/benchmark/parsers/JsonToPlugin/MapJsonThreshold.java
@@ -197,7 +197,7 @@ public class MapJsonThreshold {
                                         threshold = thres;
                                         thresholdDetected = true;
                                     } else if (method.equals("delta")) {
-                                        DeltaThreshold thres = new DeltaThreshold(delta);
+                                        DeltaThreshold thres = new DeltaThreshold(delta, ignoreNegativeDeltas);
                                         threshold = thres;
                                         thresholdDetected = true;
                                     } else if (method.equals("percentageaverage")) {
@@ -205,7 +205,7 @@ public class MapJsonThreshold {
                                         threshold = thres;
                                         thresholdDetected = true;
                                     } else if (method.equals("deltaaverage")){
-                                        DeltaAverageThreshold thres = new DeltaAverageThreshold(delta);
+                                        DeltaAverageThreshold thres = new DeltaAverageThreshold(delta, ignoreNegativeDeltas);
                                         threshold = thres;
                                         thresholdDetected = true;
                                     }

--- a/src/main/java/org/jenkinsci/plugins/benchmark/parsers/XmlToPlugin/MapXmlThreshold.java
+++ b/src/main/java/org/jenkinsci/plugins/benchmark/parsers/XmlToPlugin/MapXmlThreshold.java
@@ -43,7 +43,8 @@ public class MapXmlThreshold {
         tt_delta,
         tt_percentage,
         tt_name,
-        tt_description;
+        tt_description,
+        tt_ignoreNegativeDeltas
     }
 
     // Variables
@@ -52,6 +53,7 @@ public class MapXmlThreshold {
     private Double maximum;
     private Double delta;
     private Double percentage;
+    private Boolean ignoreNegativeDeltas;
 
     private Threshold threshold = null;
 
@@ -137,6 +139,23 @@ public class MapXmlThreshold {
                             }
                         }
                         break;
+
+                    case tt_ignoreNegativeDeltas:
+                        if (ignoreNegativeDeltas == null){
+                            attributes = nContent.getAttributes();
+                            nItem = attributes.getLength();
+                            for (int i = 0; i < nItem; ++i){
+                                Node node = attributes.item(i);
+                                if(attrName.equals(node.getNodeName())) {
+                                    try {
+                                        ignoreNegativeDeltas = Boolean.parseBoolean(node.getTextContent());
+                                    } catch (Exception e){
+                                        throw new ValidationException( Messages.IncorrectBooleanForIgnoreNegativeDeltas(parent.getFullName()) );
+                                    }
+                                    break;
+                                }
+                            }
+                        }
                 }
             }
         }
@@ -216,6 +235,21 @@ public class MapXmlThreshold {
                                 }
                             }
                             break;
+
+                        case tt_ignoreNegativeDeltas:
+                            if (ignoreNegativeDeltas == null) {
+                                for (Node nCNode = nContent.getFirstChild(); nCNode != null; nCNode = nCNode.getNextSibling()) {
+                                    if (attrName.equals(nCNode.getNodeName())) {
+                                        try {
+                                            ignoreNegativeDeltas = Boolean.parseBoolean(nCNode.getTextContent());
+                                        } catch (Exception e){
+                                            throw new ValidationException( Messages.IncorrectBooleanForIgnoreNegativeDeltas(parent.getFullName()) );
+                                        }
+                                        break;
+                                    }
+                                }
+                            }
+                            break;
                     }
                 }
             }
@@ -245,7 +279,7 @@ public class MapXmlThreshold {
                                     threshold = thres;
                                     thresholdDetected = true;
                                 } else if (method.equals("delta")) {
-                                    DeltaThreshold thres = new DeltaThreshold(delta);
+                                    DeltaThreshold thres = new DeltaThreshold(delta, ignoreNegativeDeltas);
                                     threshold = thres;
                                     thresholdDetected = true;
                                 } else if (method.equals("percentageaverage")) {
@@ -253,7 +287,7 @@ public class MapXmlThreshold {
                                     threshold = thres;
                                     thresholdDetected = true;
                                 } else if (method.equals("deltaaverage")){
-                                    DeltaAverageThreshold thres = new DeltaAverageThreshold(delta);
+                                    DeltaAverageThreshold thres = new DeltaAverageThreshold(delta, ignoreNegativeDeltas);
                                     threshold = thres;
                                     thresholdDetected = true;
                                 }
@@ -289,7 +323,7 @@ public class MapXmlThreshold {
                                         threshold = thres;
                                         thresholdDetected = true;
                                     } else if (method.equals("delta")) {
-                                        DeltaThreshold thres = new DeltaThreshold(delta);
+                                        DeltaThreshold thres = new DeltaThreshold(delta, ignoreNegativeDeltas);
                                         threshold = thres;
                                         thresholdDetected = true;
                                     } else if (method.equals("percentageaverage")) {
@@ -297,7 +331,7 @@ public class MapXmlThreshold {
                                         threshold = thres;
                                         thresholdDetected = true;
                                     } else if (method.equals("deltaaverage")){
-                                        DeltaAverageThreshold thres = new DeltaAverageThreshold(delta);
+                                        DeltaAverageThreshold thres = new DeltaAverageThreshold(delta, ignoreNegativeDeltas);
                                         threshold = thres;
                                         thresholdDetected = true;
                                     }
@@ -324,13 +358,13 @@ public class MapXmlThreshold {
                 PercentageThreshold thres = new PercentageThreshold(percentage);
                 threshold = thres;
             } else if (method.equals("delta")) {
-                DeltaThreshold thres = new DeltaThreshold(delta);
+                DeltaThreshold thres = new DeltaThreshold(delta, ignoreNegativeDeltas);
                 threshold = thres;
             } else if (method.equals("percentageaverage")) {
                 PercentageAverageThreshold thres = new PercentageAverageThreshold(percentage);
                 threshold = thres;
             } else if (method.equals("deltaaverage")){
-                DeltaAverageThreshold thres = new DeltaAverageThreshold(delta);
+                DeltaAverageThreshold thres = new DeltaAverageThreshold(delta, ignoreNegativeDeltas);
                 threshold = thres;
             }
         }
@@ -376,6 +410,8 @@ public class MapXmlThreshold {
                     return ThresholdTags.tt_delta;
                 } else if (value.equals("jbs:percentage")) {
                     return ThresholdTags.tt_percentage;
+                } else if (value.equals("jbs:ignoreNegativeDeltas")) {
+                    return ThresholdTags.tt_ignoreNegativeDeltas;
                 } else {
                     return ThresholdTags.tt_unknown;
                 }

--- a/src/main/java/org/jenkinsci/plugins/benchmark/thresholds/DeltaAverageThreshold.java
+++ b/src/main/java/org/jenkinsci/plugins/benchmark/thresholds/DeltaAverageThreshold.java
@@ -41,23 +41,26 @@ public class DeltaAverageThreshold extends Threshold{
 
     // Variables
     private final Double delta;
+    private final boolean ignoreNegativeDeltas;
     private Double average;
 
     // Constructor
     @DataBoundConstructor
-    public DeltaAverageThreshold(String testGroup, String testName, Double delta){
+    public DeltaAverageThreshold(String testGroup, String testName, Double delta, boolean ignoreNegativeDeltas){
         super(testGroup,testName, ThresholdTypes.tt_deltaAverage);
         this.delta = delta;
+        this.ignoreNegativeDeltas = ignoreNegativeDeltas;
         this.average = null;
     }
 
 
-    public DeltaAverageThreshold(Double delta) throws ValidationException{
+    public DeltaAverageThreshold(Double delta, boolean ignoreNegativeDeltas) throws ValidationException{
         super(ThresholdTypes.tt_deltaAverage);
         if (delta == null){
             throw new ValidationException(Messages.DeltaAverageThreshold_MissingDelta());
         }
         this.delta = delta;
+        this.ignoreNegativeDeltas = ignoreNegativeDeltas;
         this.average = null;
     }
 
@@ -70,8 +73,15 @@ public class DeltaAverageThreshold extends Threshold{
     public boolean isValid(int value) throws NullPointerException, ValidationException {
         if ( average == null )
             return true;
-        double calculatedDelta = Math.sqrt((value - average)*(value - average));
-        if ( delta != null && calculatedDelta > delta) {
+
+        double calculatedDelta = value - average;
+
+        if (calculatedDelta < 0 && this.ignoreNegativeDeltas == true)
+            return true;
+
+        double absValueDelta = Math.abs(calculatedDelta);
+
+        if ( delta != null && absValueDelta > delta) {
             throw new ValidationException(Messages.DeltaAverageThreshold_OutOfDeltaFromAverage(Integer.toString(value), Double.toString(delta), Double.toString(average)));
         }
         return true;
@@ -81,8 +91,15 @@ public class DeltaAverageThreshold extends Threshold{
     public boolean isValid(double value) throws NullPointerException, ValidationException {
         if ( average == null )
             return true;
-        double calculatedDelta = Math.sqrt((value - average)*(value - average));
-        if ( delta != null && calculatedDelta > delta) {
+
+        double calculatedDelta = value - average;
+
+        if (calculatedDelta < 0 && this.ignoreNegativeDeltas == true)
+            return true;
+
+        double absValueDelta = Math.abs(calculatedDelta);
+
+        if ( delta != null && absValueDelta > delta) {
             throw new ValidationException(Messages.DeltaAverageThreshold_OutOfDeltaFromAverage(Double.toString(value), Double.toString(delta), Double.toString(average)));
         }
         return true;
@@ -93,6 +110,7 @@ public class DeltaAverageThreshold extends Threshold{
 
     // Getter
     public Double getDelta() { return delta; }
+    public Boolean getIgnoreNegativeDeltas() { return ignoreNegativeDeltas; }
     public Double getAverageValue() { return average; }
 
     // Descriptor (active interactor)

--- a/src/main/java/org/jenkinsci/plugins/benchmark/thresholds/DeltaThreshold.java
+++ b/src/main/java/org/jenkinsci/plugins/benchmark/thresholds/DeltaThreshold.java
@@ -40,22 +40,25 @@ public class DeltaThreshold extends Threshold{
 
     // Variables
     private final Double delta;
+    private final boolean ignoreNegativeDeltas;
     private Double previous;
 
     // Constructor
     @DataBoundConstructor
-    public DeltaThreshold(String testGroup, String testName, Double delta){
+    public DeltaThreshold(String testGroup, String testName, Double delta, boolean ignoreNegativeDeltas){
         super(testGroup, testName, ThresholdTypes.tt_delta);
         this.delta = delta;
+        this.ignoreNegativeDeltas = ignoreNegativeDeltas;
         this.previous = null;
     }
 
-    public DeltaThreshold(Double delta) throws ValidationException {
+    public DeltaThreshold(Double delta, boolean ignoreNegativeDeltas) throws ValidationException {
         super(ThresholdTypes.tt_delta);
         if (delta == null){
             throw new ValidationException(Messages.DeltaThreshold_MissingDeltaValue());
         }
         this.delta = delta;
+        this.ignoreNegativeDeltas = ignoreNegativeDeltas;
         this.previous = null;
     }
 
@@ -68,8 +71,14 @@ public class DeltaThreshold extends Threshold{
     public boolean isValid(int value) throws NullPointerException, ValidationException {
         if ( previous == null )
             return true;
-        double calculatedDelta = Math.sqrt((value - previous)*(value - previous));
-        if ( delta != null && calculatedDelta > delta) {
+
+        double calculatedDelta = value - previous;
+        if (calculatedDelta < 0 && this.ignoreNegativeDeltas == true)
+            return true;
+
+        double absValueDelta = Math.abs(calculatedDelta);
+
+        if ( delta != null && absValueDelta > delta) {
             throw new ValidationException(Messages.DeltaThreshold_ValueOutOfDeltaFromPrevious(Integer.toString(value), Double.toString(delta), Double.toString(previous)));
         }
         return true;
@@ -79,8 +88,14 @@ public class DeltaThreshold extends Threshold{
     public boolean isValid(double value) throws NullPointerException, ValidationException {
         if ( previous == null )
             return true;
-        double calculatedDelta = Math.sqrt((value - previous)*(value - previous));
-        if ( delta != null && calculatedDelta > delta) {
+
+        double calculatedDelta = value - previous;
+        if (calculatedDelta < 0 && this.ignoreNegativeDeltas == true)
+            return true;
+
+        double absValueDelta = Math.abs(calculatedDelta);
+
+        if ( delta != null && absValueDelta > delta) {
             throw new ValidationException(Messages.DeltaThreshold_ValueOutOfDeltaFromPrevious(Double.toString(value), Double.toString(delta), Double.toString(previous)));
         }
         return true;
@@ -91,6 +106,7 @@ public class DeltaThreshold extends Threshold{
 
     // Getter
     public Double getDelta() { return delta; }
+    public Boolean getIgnoreNegativeDeltas() { return ignoreNegativeDeltas; }
     public Double getPrevious() { return previous; }
 
     // Descriptor (active interactor)

--- a/src/main/resources/org/jenkinsci/plugins/benchmark/parsers/JsonToPlugin/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/benchmark/parsers/JsonToPlugin/Messages.properties
@@ -9,3 +9,4 @@ MapJsonThreshold.WrongFormatForMaximum=Wrong format for threshold maximum value,
 MapJsonThreshold.WrongFormatForMinimum=Wrong format for threshold minimum value, expected a number.
 MapJsonThreshold.WrongFormatForDelta=Wrong format for threshold delta value, expected a number.
 MapJsonThreshold.WrongFormatForPercentage=Wrong format for threshold percentage value, expected a number.
+MapJsonThreshold.WrongFormatForIgnoreNegativeDeltas=Wrong format for ignore negative deltas value, expected a boolean.

--- a/src/main/resources/org/jenkinsci/plugins/benchmark/parsers/XmlToPlugin/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/benchmark/parsers/XmlToPlugin/Messages.properties
@@ -9,6 +9,7 @@ IncorrectDoubleForMinimum=Incorrect double format for: {0}.minimum
 IncorrectDoubleForMaximum=Incorrect double format for: {0}.maximum
 IncorrectDoubleForDelta=Incorrect double format for: {0}.delta
 IncorrectDoubleForPercentage=Incorrect double format for: {0}.percentage
+IncorrectBooleanForIgnoreNegativeDeltas=Incorrect boolean format for: {0}.ignoreNegativeDeltas
 IncorrectIntegerForId=Incorrect integer format for: {0}.id
 IncorrectDoubleForDouble=Incorrect double format for: {0}.double
 IncorrectIntegerForInteger=Incorrect integer format for: {0}.integer

--- a/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaAverageThreshold/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaAverageThreshold/config.jelly
@@ -36,4 +36,8 @@
       <f:number default="0" min="0"/>
     </f:entry>
 
+    <f:entry title="${%Ignore Negative Deltas}" field="ignoreNegativeDeltas">
+        <f:checkbox />
+    </f:entry>
+
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaAverageThreshold/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaAverageThreshold/config.properties
@@ -1,3 +1,4 @@
 Group=Group
 Result=Result
 Delta=Delta
+Ignore\ Negative\ Deltas=Ignore Negative Deltas

--- a/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaAverageThreshold/config_fr.properties
+++ b/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaAverageThreshold/config_fr.properties
@@ -1,3 +1,4 @@
 Group=Groupe
 Result=R\u00E9sultat
 Delta=Diff\u00E9rence
+Ignore\ Negative\ Deltas=ignorer les deltas négatifs

--- a/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaAverageThreshold/help-ignoreNegativeDeltas.html
+++ b/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaAverageThreshold/help-ignoreNegativeDeltas.html
@@ -1,0 +1,3 @@
+<div>
+    When checked, delta values which are less than zero are considered valid
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaAverageThreshold/help-ignoreNegativeDeltas_fr.html
+++ b/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaAverageThreshold/help-ignoreNegativeDeltas_fr.html
@@ -1,0 +1,3 @@
+<div>
+    Lorsque cette case est cochée, les valeurs delta inférieures à zéro sont considérées comme valides
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaThreshold/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaThreshold/config.jelly
@@ -36,4 +36,8 @@
         <f:number default="0" min="0"/>
     </f:entry>
 
+    <f:entry title="${%Ignore Negative Deltas}" field="ignoreNegativeDeltas">
+        <f:checkbox />
+    </f:entry>
+
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaThreshold/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaThreshold/config.properties
@@ -1,3 +1,4 @@
 Group=Group
 Result=Result
 Delta=Delta
+Ignore\ Negative\ Deltas=Ignore Negative Deltas

--- a/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaThreshold/config_fr.properties
+++ b/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaThreshold/config_fr.properties
@@ -1,3 +1,4 @@
 Group=Groupe
 Result=R\u00E9sultat
 Delta=Diff\u00E9rence
+Ignore\ Negative\ Deltas=ignorer les deltas négatifs

--- a/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaThreshold/help-ignoreNegativeDeltas.html
+++ b/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaThreshold/help-ignoreNegativeDeltas.html
@@ -1,0 +1,3 @@
+<div>
+    When checked, delta values which are less than zero are considered valid
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaThreshold/help-ignoreNegativeDeltas_fr.html
+++ b/src/main/resources/org/jenkinsci/plugins/benchmark/thresholds/DeltaThreshold/help-ignoreNegativeDeltas_fr.html
@@ -1,0 +1,3 @@
+<div>
+    Lorsque cette case est cochée, les valeurs delta inférieures à zéro sont considérées comme valides
+</div>

--- a/src/main/resources/schemas/default.json
+++ b/src/main/resources/schemas/default.json
@@ -62,7 +62,8 @@
                                                         "minimum": {"type": "minimum"},
                                                         "maximum": {"type": "maximum"},
                                                         "delta": {"type": "delta"},
-                                                        "percentage": {"type": "percentage"}
+                                                        "percentage": {"type": "percentage"},
+                                                        "ignoreNegativeDeltas": { "type": "ignoreNegativeDeltas"}
                                                     }
                                                 }
                                             }

--- a/src/main/resources/schemas/default.xml
+++ b/src/main/resources/schemas/default.xml
@@ -13,6 +13,7 @@
             <xs:element name="maximum" type="jbs:maximum"/>
             <xs:element name="delta" type="jbs:delta"/>
             <xs:element name="percentage" type="jbs:percentage"/>
+            <xs:element name="ignoreNegativeDeltas" type="jbs:ignoreNegativeDeltas"/>
         </xs:sequence>
         <xs:attribute name="method" type="jbs:method"/>
     </xs:complexType>

--- a/src/main/resources/schemas/simplest.json
+++ b/src/main/resources/schemas/simplest.json
@@ -30,7 +30,8 @@
                     "minimum": {"type": "minimum"},
                     "maximum": {"type": "maximum"},
                     "delta": {"type": "delta"},
-                    "percentage": {"type": "percentage"}
+                    "percentage": {"type": "percentage"},
+                    "ignoreNegativeDeltas": { "type": "ignoreNegativeDeltas" }
                 }
             }
         }

--- a/src/main/resources/schemas/simplest.xml
+++ b/src/main/resources/schemas/simplest.xml
@@ -23,6 +23,7 @@
             <xs:element name="maximum" type="jbs:maximum"/>
             <xs:element name="delta" type="jbs:delta"/>
             <xs:element name="percentage" type="jbs:percentage"/>
+            <xs:element name="ignoreNegativeDeltas" type="jbs:ignoreNegativeDeltas"/>
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
provides the ability for the plugin to ignore negative deltas.  this is useful for when the plugin is used for tracking performance timings, and a negative delta is a _good_ thing.  