### PR TITLE
Delay "Result page" redirect until after setResultSelected

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/benchmark/core/BenchmarkProjectAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/benchmark/core/BenchmarkProjectAction/index.jelly
@@ -200,13 +200,15 @@
           var BchPub = <st:bind value="${it}"/>
 
           table_1.on( 'click', 'tr', function () {
-            BchPub.setResultSelected($('#raw_results').DataTable().row($(this)).data()[heads]);
-            window.location.href = resultPageURL;
+            BchPub.setResultSelected($('#raw_results').DataTable().row($(this)).data()[heads], function (t) {
+              window.location.href = resultPageURL;
+            } );
           } );
 
           table_2.on( 'click', 'tr', function () {
-            BchPub.setResultSelected($('#condensed_results').DataTable().row($(this)).data()[heads]);
-            window.location.href = resultPageURL;
+            BchPub.setResultSelected($('#condensed_results').DataTable().row($(this)).data()[heads], function (t) {
+              window.location.href = resultPageURL;
+            } );
           } );
 
           $("#btn-save-raw").click( function() {


### PR DESCRIPTION
On Firefox, the AJAX call to `setResultSelected` appears to be cancelled due to the immediate redirect closing the page before the operation can start.

This is an attempt to resolve #37, but I haven't dabbled in JavaScript for about a decade, so I'm not sure if this is the right thing to do.