### PR TITLE
Fix error when using JSON with booleankey failure

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/benchmark/parsers/JsonToPlugin/MapJsonFailures.java
+++ b/src/main/java/org/jenkinsci/plugins/benchmark/parsers/JsonToPlugin/MapJsonFailures.java
@@ -143,7 +143,7 @@ public class MapJsonFailures {
             if (entryFailure.getKey().equals("key")) {
                 JsonElement eType = entryFailure.getValue();
                 if (eType.isJsonPrimitive()) {
-                    JsonPrimitive pType = eFailure.getAsJsonPrimitive();
+                    JsonPrimitive pType = eType.getAsJsonPrimitive();
                     if (pType.isString())
                         failures.add(new TestFailure(pType.getAsString(), true));
                 }


### PR DESCRIPTION
This looks like a typo - `eFailure` is referenced as an object earlier in the function, and other areas that have this same pattern reference `eType` in this spot. After this fix, I was able to add the "key" key to the "failure" object in the schema successfully.