### PR TITLE
Move to the "new POM", compile with Jenkins 2.164

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.11</version>
+    <version>3.43</version>
     <relativePath />
   </parent>
 
@@ -29,9 +29,11 @@
 
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.7</jenkins.version>
+    <jenkins.version>2.164</jenkins.version>
+    <!-- Set to 6 if your jenkins.version <= 1.611. -->
+    <java.level>8</java.level>
     <!-- Other properties you may want to use:
-         ~ java.level: set to 6 if your jenkins.version <= 1.611 ~ jenkins-test-harness.version: Jenkins Test Harness version you use to test the plugin. For Jenkins version >= 1.580.1 use JTH 2.0 or higher.
+         ~ jenkins-test-harness.version: Jenkins Test Harness version you use to test the plugin. For Jenkins version >= 1.580.1 use JTH 2.0 or higher.
          ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
          ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
     -->


### PR DESCRIPTION
At present, Jenkins 2.164 is the oldest release of Jenkins that supports compilation with Java 11. Coupled with this change is an update to use the "new POM".

Note that at this time, the oldest supported release of Jenkins according to the [official plugin documentation](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#choosing-a-version) is 2.190.1.
