### PR TITLE
Drop unsupported tt tag in favor of code

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/benchmark/core/BenchmarkPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/benchmark/core/BenchmarkPublisher.java
@@ -449,7 +449,7 @@ public class BenchmarkPublisher extends Recorder implements SimpleBuildStep {
      * The class is marked as public so that it can be accessed from views.
      * This is the class in charge of all interactions by the UI components.
      *
-     * See <tt>src/main/resources/org/jenkinsci/plugins/benchmark/BenchmarkPublisher/*.jelly</tt>
+     * See <code>src/main/resources/org/jenkinsci/plugins/benchmark/BenchmarkPublisher/*.jelly</code>
      * for the actual HTML fragment for the configuration screen.
      */
     @Extension @Symbol("benchmark") // This indicates to Jenkins that this is an implementation of an extension point.
@@ -458,7 +458,7 @@ public class BenchmarkPublisher extends Recorder implements SimpleBuildStep {
         /**
          * To persist global configuration information,
          * simply store it in a field and call save().
-         * If you don't want fields to be persisted, use <tt>transient</tt>.
+         * If you don't want fields to be persisted, use <code>transient</code>.
          */
 
         /** In order to load the persisted global configuration, you have to call load() in the constructor. */


### PR DESCRIPTION
This tag is not supported in HTML5.

Resolves this issue:
```
[ERROR] src/main/java/org/jenkinsci/plugins/benchmark/core/BenchmarkPublisher.java:452: error: tag not supported in the generated HTML version: tt
[ERROR]      * See <tt>src/main/resources/org/jenkinsci/plugins/benchmark/BenchmarkPublisher/*.jelly</tt>
```